### PR TITLE
Make C-c c request a "manual" completion

### DIFF
--- a/emacs-cody.el
+++ b/emacs-cody.el
@@ -580,7 +580,8 @@ Query and output go into the *cody-chat* buffer."
          (result (jsonrpc-request (cody--connection)
                                   'autocomplete/execute
                                   (list :filePath file
-                                        :position (list :line line :character col)))))
+                                        :position (list :line line :character col)
+                                        :triggerKind "Invoke"))))
     (cody--handle-completion-result result)))
 
 (defun cody--handle-completion-result (result)


### PR DESCRIPTION
There are many conservative heuristics at play for automatic completions. This makes `cody-request-completion` request a manual completion which is more likely to produce completions.

This relies on https://github.com/sourcegraph/cody/pull/1215 in the agent.